### PR TITLE
Changed descriptor max to maxhp. Max is a bit ambigious in this case …

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 * Added fields to NPC sheets on the combat tracker for Wounds, Temp HP, HP Adjustment, Hit Dice, and Death Saves. And added an option to disable showing them.
 
 * Support has been added for six new special damage types:
-  * max: The target's maximum hitpoints are reduced by the damage dealt.
+  * maxhp: The target's maximum hitpoints are reduced by the damage dealt.
   * steal*: The attacker is healed for the damage dealt to the target.
   * hsteal: The attacker is healed for half of the damage dealt to the target.
   * stealtemp*: The attacker is gains temporary hitpoints equivalent to the damage dealt.

--- a/campaign/record_power_roll.xml
+++ b/campaign/record_power_roll.xml
@@ -6,7 +6,7 @@
 				<script>
 					function onInit()
 						parameters[1].labelsres[1] = parameters[1].labelsres[1] .. "|power_label_healtypemax";
-						parameters[1].values[1] = parameters[1].values[1] .. "|max";
+						parameters[1].values[1] = parameters[1].values[1] .. "|maxhp";
 						if super and super.onInit then
 							super.onInit();
 						end

--- a/ct/ct_client.xml
+++ b/ct/ct_client.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <root>
-	<windowclass name="combattracker_client" merge="join">
+	<windowclass name="sub_ct_header_client" merge="join">
 		<script>
 			function onInit()
 				changeHealthDisplay();
@@ -21,12 +21,12 @@
 		</script>
 		<sheetdata>
 			<!-- Shift HP and Temp right, move Wnd to where HP was -->
-			<label_ct_right name="label_hp" insertbefore="label_wounds">
+			<label_ct_header_right name="label_hp" insertbefore="label_wounds">
 				<!-- Be more specific about Max HP -->
 				<static textres="ct_label_max" />
 				<tooltip textres="ct_tooltip_max" />
-			</label_ct_right>
-			<label_ct_right name="label_temp" insertbefore="label_wounds" />
+			</label_ct_header_right>
+			<label_ct_header_right name="label_temp" insertbefore="label_wounds" />
 		</sheetdata>
 	</windowclass>
 </root>

--- a/ct/ct_host.xml
+++ b/ct/ct_host.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <root>
-	<windowclass name="combattracker_host" merge="join">
+	<windowclass name="sub_ct_header_host" merge="join">
 		<script>
 			function onInit()
 				changeHealthDisplay();
@@ -21,16 +21,16 @@
 		</script>
 		<sheetdata>
 			<!-- Shift HP and Temp right, move Wnd to where HP was -->
-			<label_ct_right name="label_hp">
+			<label_ct_header_right name="label_hp">
 				<!-- Be more specific about Max HP -->
 				<static textres="ct_label_max" />
 				<tooltip textres="ct_tooltip_max" />
-			</label_ct_right>
-			<label_ct_right name="label_wounds" merge="delete" />
-			<label_ct_right name="label_wounds" insertbefore="label_init">
+			</label_ct_header_right>
+			<label_ct_header_right name="label_wounds" merge="delete" />
+			<label_ct_header_right name="label_wounds" insertbefore="label_init">
 				<static textres="ct_label_wounds" />
 				<tooltip textres="ct_tooltip_wounds" />
-			</label_ct_right>
+			</label_ct_header_right>
 		</sheetdata>
 	</windowclass>
 </root>

--- a/scripts/manager_action_damage_ca.lua
+++ b/scripts/manager_action_damage_ca.lua
@@ -12,13 +12,13 @@ local messageDamageOriginal;
 local DAMAGE_RATE_PATTERN = "'(%d*%.?%d+)'";
 
 function onInit()
-	table.insert(DataCommon.dmgtypes, "max");
+	table.insert(DataCommon.dmgtypes, "maxhp");
 	table.insert(DataCommon.dmgtypes, "steal");
 	table.insert(DataCommon.dmgtypes, "hsteal");
 	table.insert(DataCommon.dmgtypes, "stealtemp");
 	table.insert(DataCommon.dmgtypes, "hstealtemp");
 	table.insert(DataCommon.dmgtypes, DAMAGE_RATE_PATTERN);
-	table.insert(DataCommon.specialdmgtypes, "max");
+	table.insert(DataCommon.specialdmgtypes, "maxhp");
 	table.insert(DataCommon.specialdmgtypes, "steal");
 	table.insert(DataCommon.specialdmgtypes, "hsteal");
 	table.insert(DataCommon.specialdmgtypes, "stealtemp");
@@ -67,7 +67,7 @@ function applyDamage(rSource, rTarget, rRoll)
 				rSource = rSwap;
 			end
 		elseif decodeResult.sType == "heal" then
-			if string.match(rRoll.sDesc, "%[HEAL") and string.match(rRoll.sDesc, "%[MAX%]") then
+			if string.match(rRoll.sDesc, "%[HEAL") and  rRoll.sSubtype == 'maxhp' then
 				applyMaxHeal(rTarget, rRoll.nTotal);
 			end
 		elseif decodeResult.sType == "recovery" and (sTargetNodeType ~= "pc") then
@@ -143,7 +143,7 @@ end
 
 function decodeDamageText(nDamage, sDamageDesc)
 	local decodeResult = decodeDamageTextOriginal(nDamage, sDamageDesc);
-	if string.match(sDamageDesc, "%[HEAL") and string.match(sDamageDesc, "%[MAX%]") then
+	if string.match(sDamageDesc, "%[HEAL") and string.match(sDamageDesc, "%[MAXHP%]") then
 		decodeResult.sTypeOutput = "Maximum hit points";
 	end
 	return decodeResult;
@@ -245,7 +245,7 @@ function resolveDamage(rTarget, rRoll, rComplexDamage)
 				bCheckTransfer = false;
 			end
 
-			if type == "max" then
+			if type == "maxhp" then
 				nMax = 1;
 				bCheckMax = true;
 			elseif type == "steal" then

--- a/scripts/manager_action_heal_ca.lua
+++ b/scripts/manager_action_heal_ca.lua
@@ -12,8 +12,8 @@ end
 
 function getRoll(rActor, rAction)
 	local rRoll = getRollOriginal(rActor, rAction);
-	if rAction.subtype == "max" then
-		rRoll.sDesc = rRoll.sDesc .. " [MAX]";
+	if rAction.subtype == "maxhp" then
+		rRoll.sSubtype = rAction.subtype
 	end
 	return rRoll;
 end

--- a/scripts/manager_action_recovery_ca.lua
+++ b/scripts/manager_action_recovery_ca.lua
@@ -30,11 +30,11 @@ function modRecovery(rSource, rTarget, rRoll)
 			end
 			rRoll.nMod = rRoll.nMod + nMod;
 		end
-		local tEffects = EffectManager5E.getEffectsByType(rSource, 'HD', {'max'});
+		local tEffects = EffectManager5E.getEffectsByType(rSource, "HD", {"max"});
 		for _,tEffect in pairs(tEffects) do
 			for _,remainder in pairs(tEffect.remainder) do
-				if remainder:lower() == 'max' then
-					rRoll.sDesc = rRoll.sDesc .. ' [MAX]';
+				if remainder:lower() == "max" then
+					rRoll.sDesc = rRoll.sDesc .. " [MAX]";
 				end
 			end
 		end

--- a/scripts/manager_hp.lua
+++ b/scripts/manager_hp.lua
@@ -420,7 +420,12 @@ function getConAdjustment(nodeChar)
 end
 
 function getEffectAdjustment(nodeChar)
-	local nMod = EffectManager5E.getEffectsBonus(nodeChar, "MAXHP", true);
+	local nMod, _, nTotalPercent = EffectManager5E.getEffectsBonus(nodeChar, "MAXHP", true);
+	if nTotalPercent and nTotalPercent ~= 0 then
+		local fields = HpManager.getHealthFields(nodeChar);
+		local nBase = DB.getValue(nodeChar, fields.base, 0);
+		nMod = math.floor((nBase + nMod) * nTotalPercent + nMod);
+	end
 	return nMod;
 end
 

--- a/scripts/manager_hp.lua
+++ b/scripts/manager_hp.lua
@@ -424,7 +424,8 @@ function getEffectAdjustment(nodeChar)
 	if nTotalPercent and nTotalPercent ~= 0 then
 		local fields = HpManager.getHealthFields(nodeChar);
 		local nBase = DB.getValue(nodeChar, fields.base, 0);
-		nMod = math.floor((nBase + nMod) * nTotalPercent + nMod);
+		local nAdjust = DB.getValue(nodeChar, fields.adjust, 0);
+		nMod = math.floor((nBase + nAdjust + nMod) * nTotalPercent + nMod);
 	end
 	return nMod;
 end

--- a/scripts/manager_power_ca.lua
+++ b/scripts/manager_power_ca.lua
@@ -1,5 +1,5 @@
--- 
--- Please see the license file included with this distribution for 
+--
+-- Please see the license file included with this distribution for
 -- attribution and copyright information.
 --
 
@@ -16,7 +16,7 @@ end
 
 function getPCPowerHealActionText(nodeAction)
 	local sHeal = getPCPowerHealActionTextOriginal(nodeAction);
-	if sHeal ~= "" and DB.getValue(nodeAction, "healtype", "") == "max" then
+	if sHeal ~= "" and DB.getValue(nodeAction, "healtype", "") == "maxhp" then
 		local nPos = string.find(sHeal, " %[SELF%]");
 		if nPos then
 			sHeal = sHeal:sub(1, nPos-1) .. " maximum" .. sHeal:sub(nPos);

--- a/strings/strings.xml
+++ b/strings/strings.xml
@@ -26,7 +26,7 @@
 	<string name="menu_reparse_hitdice">Reparse Hit Dice</string>
 
 	<string name="power_label_healtypecur">CUR</string>
-	<string name="power_label_healtypemax">MAX</string>
+	<string name="power_label_healtypemax">MAXHP</string>
 
 	<string name="hide_hp_header">Remove hitpoint adjustment</string>
 	<string name="show_hp_header">Configure hitpoint adjustment</string>


### PR DESCRIPTION
I think maxhp makes more sense here for a few reasons:

max is generally thought of as maximize the roll. BCEG allows for heal to use a max descriptor to maximize the roll which ends up conflicting. maxhp is used elsewhere in CA to denote increasing the maxhp so this change seems to get everything a bit more consistent as well as avoid conflict.